### PR TITLE
Compute secret hash with username supplied by password challenge

### DIFF
--- a/cognitosrp.go
+++ b/cognitosrp.go
@@ -160,7 +160,7 @@ func (csrp *CognitoSRP) PasswordVerifierChallenge(challengeParms map[string]stri
 		"PASSWORD_CLAIM_SECRET_BLOCK": secretBlockB64,
 		"PASSWORD_CLAIM_SIGNATURE":    signature,
 	}
-	if secret, err := csrp.GetSecretHash(csrp.username); err == nil {
+	if secret, err := csrp.GetSecretHash(internalUsername); err == nil {
 		response["SECRET_HASH"] = secret
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/alexrudd/cognito-srp/v4
+module github.com/peterallworth/cognito-srp/v4
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/peterallworth/cognito-srp/v4
+module github.com/alexrudd/cognito-srp/v4
 
 go 1.15


### PR DESCRIPTION
This PR proposes a fix to issue #7, Cognito returns NotAuthorizedException when app client secret is present.
